### PR TITLE
Fix Sweccathon guide links and update Mesocosm CLI docs

### DIFF
--- a/content/Sweccathon/START_HERE.md
+++ b/content/Sweccathon/START_HERE.md
@@ -14,7 +14,15 @@ tags:
 
 # Mesocosm CLI
 
-Central hub for the **mesocosm** command-line tool — SWECC's BenchAnything / Mesocosm platform. Install with `pip install swecc-mesocosm`; no backend source code required.
+Central hub for the **mesocosm** command-line tool — SWECC's BenchAnything / Mesocosm platform.
+
+**Install with pip** (recommended — the package is published on PyPI):
+
+```bash
+pip install swecc-mesocosm
+```
+
+Use **`pip`**, not Homebrew, `uv`, Poetry, or other wrappers, unless you know what you are doing. Those can install a different Python environment or an outdated build and cause confusing `mesocosm: command not found` errors. No backend source code required.
 
 ## Quick start
 

--- a/content/Sweccathon/START_HERE.md
+++ b/content/Sweccathon/START_HERE.md
@@ -40,15 +40,15 @@ mesocosm run create --domain YOUR_DOMAIN_ID --vow-version 1.0.0 --model gemini/g
 
 ## Guides
 
-- [[mesocosm/getting-started]] — Install, first commands, production vs local
-- [[mesocosm/local-development]] — Ollama loop, adapter, `run local`
-- [[mesocosm/authentication]] — Login, guest, tokens, logout
-- [[mesocosm/teams]] — Create, join, active team context
-- [[mesocosm/submitting-environments]] — `env submit`, GitHub requirements
-- [[mesocosm/running-benchmarks]] — Platform runs, local runs, eval
-- [[mesocosm/showcase]] — Replay JSON, `run export`
-- [[mesocosm/command-reference]] — Full parameter reference
-- [[mesocosm/troubleshooting]] — `doctor`, URLs, common errors
+- [[Sweccathon/mesocosm/getting-started]] — Install, first commands, production vs local
+- [[Sweccathon/mesocosm/local-development]] — Ollama loop, adapter, `run local`
+- [[Sweccathon/mesocosm/authentication]] — Login, guest, tokens, logout
+- [[Sweccathon/mesocosm/teams]] — Create, join, active team context
+- [[Sweccathon/mesocosm/submitting-environments]] — `env submit`, GitHub requirements
+- [[Sweccathon/mesocosm/running-benchmarks]] — Platform runs, local runs, eval
+- [[Sweccathon/mesocosm/showcase]] — Replay JSON, `run export`
+- [[Sweccathon/mesocosm/command-reference]] — Full parameter reference
+- [[Sweccathon/mesocosm/troubleshooting]] — `doctor`, URLs, common errors
 
 ## Who this is for
 
@@ -62,11 +62,11 @@ mesocosm run create --domain YOUR_DOMAIN_ID --vow-version 1.0.0 --model gemini/g
 | **Production** (default) | `mesocosm auth login`, `env submit`, `run create` → `https://api.swecc.org` |
 | **Local** | `export MESOCOSM_LOCAL=1`, `mesocosm doctor --local`, `mesocosm run local` with Ollama |
 
-Details: [[mesocosm/getting-started#configure|Configure]] · [[mesocosm/troubleshooting|Troubleshooting]]
+Details: [[Sweccathon/mesocosm/getting-started#configure|Configure]] · [[Sweccathon/mesocosm/troubleshooting|Troubleshooting]]
 
 ## Related vault notes
 
-- [[SWECCathon 2026 Information Hub]] — hackathon logistics and links
+- [[Sweccathon/SWECCathon 2026 Information Hub]] — hackathon logistics and links
 
 ## CLI help
 
@@ -76,4 +76,4 @@ mesocosm auth --help
 mesocosm run --help
 ```
 
-Every flag and default: [[mesocosm/command-reference|Command reference]].
+Every flag and default: [[Sweccathon/mesocosm/command-reference|Command reference]].

--- a/content/Sweccathon/SWECCathon 2026 Information Hub.md
+++ b/content/Sweccathon/SWECCathon 2026 Information Hub.md
@@ -8,7 +8,7 @@ last updated: 2026-05-26T13:33:00
 Welcome to the much-anticipated 2025 SWECCathon! We are thrilled to have you here with us. This page should give you all the necessary logistical information to ensure you have a great time hacking/mentoring/judging. Have fun! ✨ 
 
 **Sponsored by:**
-![[Pasted image 20260526133352.png]]
+![[Sweccathon/Pasted image 20260526133352.png]]
 
 ## Agenda: 
 ### Opening Ceremony
@@ -16,7 +16,7 @@ Welcome to the much-anticipated 2025 SWECCathon! We are thrilled to have you her
 
 ## Hackathon Information
 
-- [[START_HERE|Mesocosm CLI]] — install, local dev, submit, benchmark runs
+- [[Sweccathon/START_HERE|Mesocosm CLI]] — install, local dev, submit, benchmark runs
 - General Hackathon Information — _(add links as needed)_
 
 

--- a/content/Sweccathon/mesocosm/authentication.md
+++ b/content/Sweccathon/mesocosm/authentication.md
@@ -65,7 +65,7 @@ mesocosm auth whoami
 
 Calls `GET /v1/me` and prints your principal as JSON.
 
-Useful after login or guest to confirm the token and URL are correct. If connection fails, see [[mesocosm/troubleshooting|Troubleshooting]].
+Useful after login or guest to confirm the token and URL are correct. If connection fails, see [[Sweccathon/mesocosm/troubleshooting|Troubleshooting]].
 
 ## Logout
 
@@ -111,11 +111,11 @@ Most commands accept a parent flag:
 mesocosm auth whoami --bench-url https://api.swecc.org/bench
 ```
 
-Resolution order for bench-api URL is documented in [[mesocosm/command-reference#global-configuration|Command reference — Global configuration]].
+Resolution order for bench-api URL is documented in [[Sweccathon/mesocosm/command-reference#global-configuration|Command reference — Global configuration]].
 
 ## Related
 
-- [[mesocosm/teams|Teams]] — requires member auth
-- [[mesocosm/submitting-environments|Submitting environments]] — requires member auth
-- [[mesocosm/troubleshooting#authentication-issues|Troubleshooting — auth errors]]
-- [[mesocosm/command-reference#authentication|Command reference — auth commands]]
+- [[Sweccathon/mesocosm/teams|Teams]] — requires member auth
+- [[Sweccathon/mesocosm/submitting-environments|Submitting environments]] — requires member auth
+- [[Sweccathon/mesocosm/troubleshooting#authentication-issues|Troubleshooting — auth errors]]
+- [[Sweccathon/mesocosm/command-reference#authentication|Command reference — auth commands]]

--- a/content/Sweccathon/mesocosm/command-reference.md
+++ b/content/Sweccathon/mesocosm/command-reference.md
@@ -6,7 +6,7 @@ aliases:
 
 # Command reference
 
-Complete parameter reference for the **`mesocosm`** CLI (`pip install swecc-mesocosm`, currently **0.2.14** on swecc-core main).
+Complete parameter reference for the **`mesocosm`** CLI. Install with **`pip install swecc-mesocosm`** (see [[Sweccathon/mesocosm/getting-started#install|Getting started — Install]]).
 
 **See also:** [[Sweccathon/START_HERE|Mesocosm CLI]], [[Sweccathon/mesocosm/getting-started|Getting started]], [[Sweccathon/mesocosm/local-development|Local development]].
 

--- a/content/Sweccathon/mesocosm/command-reference.md
+++ b/content/Sweccathon/mesocosm/command-reference.md
@@ -6,9 +6,9 @@ aliases:
 
 # Command reference
 
-Complete parameter reference for the **`mesocosm`** CLI (`pip install swecc-mesocosm`).
+Complete parameter reference for the **`mesocosm`** CLI (`pip install swecc-mesocosm`, currently **0.2.14** on swecc-core main).
 
-**See also:** [[START_HERE|Mesocosm CLI]], [[mesocosm/getting-started|Getting started]], [[mesocosm/local-development|Local development]].
+**See also:** [[Sweccathon/START_HERE|Mesocosm CLI]], [[Sweccathon/mesocosm/getting-started|Getting started]], [[Sweccathon/mesocosm/local-development|Local development]].
 
 Run `mesocosm --help` or `mesocosm run --help` for the built-in command tree.
 
@@ -41,6 +41,7 @@ Run `mesocosm --help` or `mesocosm run --help` for the built-in command tree.
 | `run local` | see below | Bench locally with Ollama and benchanything.json |
 | `env submit` | `--name`; `--github-url`; … | Submit GitHub repo as developer environment |
 | `env list` | `--team`; `--solo` | List your developer environments |
+| `env delete` | `ENV_ID` | Delete a developer environment (member auth) |
 | `run create` | `--domain`; `--vow-version`; … | Start platform bench run via API |
 | `run export` | `RUN_ID`; `-o` / `--output` | Download run JSON for showcase or replay |
 | `register` | `domain.py`; `--auto-id`; `--publish` | Legacy register domain.py; prefer env submit |
@@ -69,7 +70,7 @@ Written by `auth login`, `auth guest`, `team use`, `team clear`, and `team creat
 
 | Variable | Used by | Description |
 | --- | --- | --- |
-| `MESOCOSM_LOCAL` | URL defaults, `doctor --local` | When set to `1`, `true`, `yes`, or `on`, use local URLs (`127.0.0.1:8000` server, `:8010` bench-api, `:8765` adapter) unless overridden. See [[mesocosm/getting-started#configure]] (Configure). |
+| `MESOCOSM_LOCAL` | URL defaults, `doctor --local` | When set to `1`, `true`, `yes`, or `on`, use local URLs (`127.0.0.1:8000` server, `:8010` bench-api, `:8765` adapter) unless overridden. See [[Sweccathon/mesocosm/getting-started#configure]] (Configure). |
 | `MESOCOSM_BASE_URL` | `--base-url`, URL resolution | bench-api base URL. Production must include `/bench` (e.g. `https://api.swecc.org/bench`). |
 | `SWECC_BENCH_URL` | URL resolution | Alias for bench-api base URL. |
 | `BENCH_API_URL` | URL resolution | Third alias for bench-api base URL. |
@@ -79,6 +80,7 @@ Written by `auth login`, `auth guest`, `team use`, `team clear`, and `team creat
 | `SWECC_BENCH_CREDENTIALS` | Credential store | Path to JSON credentials file. |
 | `MESOCOSM_ENV_URL` | `doctor --local` | Override env adapter URL (default `http://127.0.0.1:8765`). |
 | `MESOCOSM_ADAPTER_URL` | `doctor --local` | Alias for env adapter URL. |
+| `BENCH_AUTH_DISABLED` | bench_common session (dev) | When `1`/`true`/`yes`, skip auth and use empty bearer (local bench-api dev only). |
 
 **Resolution order (member bench-api URL):** CLI `--bench-url` / `--base-url` → environment variables above → saved `bench_url` in credentials → derive from `server_url` → `MESOCOSM_LOCAL` → production default.
 
@@ -96,7 +98,7 @@ Written by `auth login`, `auth guest`, `team use`, `team clear`, and `team creat
 
 Many platform commands attach `team_id` from credentials `active_team_id`, unless you pass `--team TEAM_ID` or `--solo`. Set active team with `mesocosm team use TEAM_ID` or `team create --use`.
 
-See [[mesocosm/teams|Teams]].
+See [[Sweccathon/mesocosm/teams|Teams]].
 
 ---
 
@@ -112,7 +114,7 @@ See [[mesocosm/teams|Teams]].
 | `--bench-url` | No | bench-api URL stored after login. Default derived from server (prod → `https://api.swecc.org/bench`, local server → `:8010`). |
 | *(interactive)* | Yes | Prompts for **username** (default: OS username) and **password**. No `--username` / `--password` flags. |
 
-**After success:** Writes `mode: member`, `token`, `server_url`, `bench_url`. For CI, use `SWECC_BENCH_TOKEN` ([[mesocosm/authentication|Authentication]]).
+**After success:** Writes `mode: member`, `token`, `server_url`, `bench_url`. For CI, use `SWECC_BENCH_TOKEN` ([[Sweccathon/mesocosm/authentication|Authentication]]).
 
 ### `mesocosm auth token`
 
@@ -208,7 +210,7 @@ Same as `team show` for `code show`. `code regenerate` rotates join code (owner)
 
 **Writes:** `benchanything.json`, `adapter.py`, `env.py`, `requirements.txt`, `LOCAL_DEV.md`, `showcase/README.md`, `showcase/replay.example.json`.
 
-See [[mesocosm/local-development|Local development]].
+See [[Sweccathon/mesocosm/local-development|Local development]].
 
 ---
 
@@ -263,7 +265,7 @@ See [[mesocosm/local-development|Local development]].
 | `-o`, `--output` | No | Write JSON to file; default stdout. |
 | `--bench-url` | No | Parent flag. |
 
-**API:** `GET /v1/runs/{run_id}/export`. See [[mesocosm/showcase|Showcase]].
+**API:** `GET /v1/runs/{run_id}/export`. See [[Sweccathon/mesocosm/showcase|Showcase]].
 
 ### `mesocosm run get`
 
@@ -301,7 +303,7 @@ See [[mesocosm/local-development|Local development]].
 | `--solo` | No | Force solo scope (no `team_id`). |
 | `--bench-url` | No | Parent flag. |
 
-See [[mesocosm/submitting-environments|Submitting environments]].
+See [[Sweccathon/mesocosm/submitting-environments|Submitting environments]].
 
 ### `mesocosm env list`
 
@@ -310,6 +312,17 @@ See [[mesocosm/submitting-environments|Submitting environments]].
 | `--team` | No | Explicit team id filter. |
 | `--solo` | No | List solo-scoped environments only. |
 | `--bench-url` | No | Parent flag. |
+
+### `mesocosm env delete`
+
+**Summary:** Delete a developer environment by id (member auth).
+
+| Parameter | Required | Description |
+| --- | --- | --- |
+| `ENV_ID` | Yes | Developer environment id from `env list` or submit output. |
+| `--bench-url` | No | Parent flag. |
+
+**API:** `DELETE /v1/developer/environments/{env_id}`.
 
 ---
 
@@ -341,16 +354,20 @@ See [[mesocosm/submitting-environments|Submitting environments]].
 
 **Exit code:** `0` if checks pass, `1` otherwise. Prints JSON with `issues` and hints (e.g. missing `/bench` on prod).
 
-See [[mesocosm/troubleshooting|Troubleshooting]].
+**Local profile:** With `--local` or `MESOCOSM_LOCAL=1`, `doctor` passes if the env adapter health check succeeds — bench-api can be down, which is fine for the Ollama + `run local` loop.
+
+See [[Sweccathon/mesocosm/troubleshooting|Troubleshooting]].
 
 ### `mesocosm validate` {#mesocosm-validate}
 
-**Summary:** Validate domain registration JSON against policy (offline, no HTTP).
+**Summary:** Validate JSON against bundled policy constraints (offline, no HTTP).
 
 | Parameter | Required | Description |
 | --- | --- | --- |
-| `FILE` | Yes | Path to JSON file, or `-` for stdin. Shape: POST `/v1/domains` body. |
+| `FILE` | Yes | Path to JSON file, or `-` for stdin. Auto-detects **`benchanything.json` manifest** shape or legacy **POST `/v1/domains` register body**. |
 | `--base-url` | No | Declared but unused (no network). |
+
+**Output:** JSON with `ok`, `issues`, `suggested_fixes`, `rules_version`, and optional `schema: benchanything_manifest`.
 
 **Exit code:** `0` if validation `ok`, else `1`.
 
@@ -374,6 +391,22 @@ See [[mesocosm/troubleshooting|Troubleshooting]].
 | `--base-url` | No | bench-api base URL. |
 
 **Exit:** Non-zero if episode status is `failed`, `cancelled`, or `error`.
+
+### `run create` vs `eval run`
+
+Both call `POST /v1/runs`, but they target different workflows:
+
+| | `run create` | `eval run` |
+| --- | --- | --- |
+| Domain flag | `--domain` | `--domain-id` |
+| Episodes | `--episodes` | `--num-episodes` |
+| Parallelism | `--parallel` | `--max-parallel` |
+| Default `max_tokens` | 512 | 4096 |
+| `--vow-version` | required | optional (from domain record) |
+| Draft domains | no guard | `--require-published` / `--allow-draft` |
+| Teams / visibility / env-id | yes | no |
+
+Prefer **`run create`** for hackathon platform benchmarks; use **`eval run`** for developer eval workflows.
 
 ### `mesocosm eval run`
 

--- a/content/Sweccathon/mesocosm/getting-started.md
+++ b/content/Sweccathon/mesocosm/getting-started.md
@@ -47,7 +47,7 @@ This scaffolds:
 | `LOCAL_DEV.md` | Short local-dev cheat sheet in your repo |
 | `showcase/` | Placeholder for replay exports |
 
-See [[mesocosm/local-development|Local development]] for the two-terminal workflow.
+See [[Sweccathon/mesocosm/local-development|Local development]] for the two-terminal workflow.
 
 ## First commands
 
@@ -55,6 +55,7 @@ See [[mesocosm/local-development|Local development]] for the two-terminal workfl
 | --- | --- |
 | Check CLI | `mesocosm --help` |
 | Check platform reachability | `mesocosm doctor` |
+| Validate manifest before submit | `mesocosm validate benchanything.json` |
 | Log in (member) | `mesocosm auth login` |
 | Try without an account | `mesocosm auth guest` |
 | Who am I? | `mesocosm auth whoami` |
@@ -99,7 +100,7 @@ With `MESOCOSM_LOCAL=1`, defaults typically become:
 
 `mesocosm run local` uses Ollama on your machine and does not require a running bench-api unless you are also testing platform commands locally.
 
-Full details: [[mesocosm/troubleshooting#urls-and-environment-variables|Troubleshooting — URLs and environment variables]].
+Full details: [[Sweccathon/mesocosm/troubleshooting#urls-and-environment-variables|Troubleshooting — URLs and environment variables]].
 
 ## Configure {#configure}
 
@@ -126,7 +127,7 @@ Typical keys: `mode` (`member` or `guest`), `token`, `server_url`, `bench_url`, 
 | `SWECC_BENCH_TOKEN` | Member JWT for scripts/CI (skip interactive login) |
 | `SWECC_BENCH_GUEST_TOKEN` | Guest token for API calls |
 
-See [[mesocosm/command-reference#global-configuration|Command reference — Global configuration]] for the full list.
+See [[Sweccathon/mesocosm/command-reference#global-configuration|Command reference — Global configuration]] for the full list.
 
 ### Non-interactive auth
 
@@ -138,27 +139,28 @@ export SWECC_BENCH_TOKEN='your-member-jwt'
 mesocosm auth guest
 ```
 
-See [[mesocosm/authentication|Authentication]].
+See [[Sweccathon/mesocosm/authentication|Authentication]].
 
 ## Typical workflows
 
 ### Environment author
 
 1. `mesocosm init` → edit `env.py` / `benchanything.json`
-2. [[mesocosm/local-development|Local development]] with Ollama
-3. [[mesocosm/authentication|Authentication]] → [[mesocosm/submitting-environments|Submitting environments]]
-4. [[mesocosm/running-benchmarks|Running benchmarks]] on the platform
-5. Optional: [[mesocosm/showcase|Showcase]] export
+2. `mesocosm validate benchanything.json`
+3. [[Sweccathon/mesocosm/local-development|Local development]] with Ollama
+4. [[Sweccathon/mesocosm/authentication|Authentication]] → [[Sweccathon/mesocosm/submitting-environments|Submitting environments]]
+5. [[Sweccathon/mesocosm/running-benchmarks|Running benchmarks]] on the platform
+6. Optional: [[Sweccathon/mesocosm/showcase|Showcase]] export
 
 ### Platform user (no env repo)
 
 1. `mesocosm auth login` or `auth guest`
-2. [[mesocosm/teams|Teams]] (optional)
+2. [[Sweccathon/mesocosm/teams|Teams]] (optional)
 3. `mesocosm run create` against an existing domain
 4. `mesocosm run get RUN_ID` / `mesocosm run export RUN_ID`
 
 ## Next steps
 
-- [[mesocosm/local-development|Local development]] — Ollama + adapter loop
-- [[mesocosm/authentication|Authentication]] — Member vs guest
-- [[mesocosm/command-reference|Command reference]] — All commands and flags
+- [[Sweccathon/mesocosm/local-development|Local development]] — Ollama + adapter loop
+- [[Sweccathon/mesocosm/authentication|Authentication]] — Member vs guest
+- [[Sweccathon/mesocosm/command-reference|Command reference]] — All commands and flags

--- a/content/Sweccathon/mesocosm/getting-started.md
+++ b/content/Sweccathon/mesocosm/getting-started.md
@@ -10,9 +10,19 @@ Install the Mesocosm CLI, run your first local benchmark, then connect to the SW
 
 ## Install
 
+Use **`pip`** — the Mesocosm CLI is distributed on PyPI as `swecc-mesocosm`:
+
 ```bash
 pip install swecc-mesocosm
 mesocosm --version
+```
+
+**Why pip?** SWECC docs and support assume a plain `pip install`. Other package managers (`uv`, Poetry, conda, Homebrew, etc.) may pin a different Python or an older wheel. If something breaks, retry in a fresh virtualenv with pip first:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install swecc-mesocosm
 ```
 
 The package provides:

--- a/content/Sweccathon/mesocosm/local-development.md
+++ b/content/Sweccathon/mesocosm/local-development.md
@@ -24,7 +24,7 @@ Iterate on `env.py` and `benchanything.json` on your machine **before** submitti
 
 The file created by `mesocosm init` is for **optional libraries your environment imports** (for example NumPy). You do **not** need `pip install -r requirements.txt` just to run `adapter.py` and `mesocosm run local` — the CLI already includes the HTTP stack.
 
-When you [[mesocosm/submitting-environments|submit]] to the platform, Mesocosm installs those dependencies in the cloud runtime.
+When you [[Sweccathon/mesocosm/submitting-environments|submit]] to the platform, Mesocosm installs those dependencies in the cloud runtime.
 
 ## Dev loop
 
@@ -74,7 +74,7 @@ mesocosm run local
 | `--seeds` | — | Space-separated integer seeds |
 | `--quiet` | — | Less progress output |
 
-Full reference: [[mesocosm/command-reference#mesocosm-run-local|Command reference — run local]].
+Full reference: [[Sweccathon/mesocosm/command-reference#mesocosm-run-local|Command reference — run local]].
 
 ## Ship to the platform
 
@@ -97,7 +97,7 @@ mesocosm run create \
 
 Platform runs use **cloud models** on SWECC infrastructure. Ollama is only for your machine.
 
-See [[mesocosm/submitting-environments|Submitting environments]] and [[mesocosm/running-benchmarks|Running benchmarks]].
+See [[Sweccathon/mesocosm/submitting-environments|Submitting environments]] and [[Sweccathon/mesocosm/running-benchmarks|Running benchmarks]].
 
 ## Legacy `domain.py` repos
 
@@ -111,6 +111,6 @@ New projects should prefer `mesocosm init` + `env submit`.
 
 ## Related
 
-- [[mesocosm/getting-started|Getting started]]
-- [[mesocosm/troubleshooting#local-development-issues|Troubleshooting — local checks]]
-- [[mesocosm/command-reference|Command reference]]
+- [[Sweccathon/mesocosm/getting-started|Getting started]]
+- [[Sweccathon/mesocosm/troubleshooting#local-development-issues|Troubleshooting — local checks]]
+- [[Sweccathon/mesocosm/command-reference|Command reference]]

--- a/content/Sweccathon/mesocosm/local-development.md
+++ b/content/Sweccathon/mesocosm/local-development.md
@@ -10,7 +10,7 @@ Iterate on `env.py` and `benchanything.json` on your machine **before** submitti
 
 ## Prerequisites
 
-1. **CLI:** `pip install swecc-mesocosm`
+1. **CLI:** `pip install swecc-mesocosm` (use pip — see [[Sweccathon/mesocosm/getting-started#install|Getting started — Install]])
 2. **Project:** `mesocosm init` in your env directory (or use an existing repo with the same layout)
 3. **Ollama:** Install from [ollama.com](https://ollama.com), then pull a model:
 

--- a/content/Sweccathon/mesocosm/running-benchmarks.md
+++ b/content/Sweccathon/mesocosm/running-benchmarks.md
@@ -18,7 +18,7 @@ Mesocosm supports **local** benchmarks (Ollama + your adapter) and **platform** 
 | **Auth** | None required | Member or guest session |
 | **Registers domain** | No | Uses existing domain from submit/register |
 
-Local workflow: [[mesocosm/local-development|Local development]].
+Local workflow: [[Sweccathon/mesocosm/local-development|Local development]].
 
 ## Platform run: `run create`
 
@@ -57,7 +57,7 @@ mesocosm run create \
 
 ### Auth
 
-Uses your saved session (member or guest). For teams, set [[mesocosm/teams|active team]] or pass `--team` / `--solo`.
+Uses your saved session (member or guest). For teams, set [[Sweccathon/mesocosm/teams|active team]] or pass `--team` / `--solo`.
 
 ## Inspect a run
 
@@ -75,7 +75,7 @@ mesocosm run episodes RUN_ID --traces
 mesocosm run export RUN_ID -o showcase/my-replay.json
 ```
 
-See [[mesocosm/showcase|Showcase]].
+See [[Sweccathon/mesocosm/showcase|Showcase]].
 
 ## Eval commands (API-driven)
 
@@ -134,7 +134,7 @@ mesocosm run export RUN_ID -o showcase/replay.json
 
 ## Related
 
-- [[mesocosm/local-development|Local development]]
-- [[mesocosm/submitting-environments|Submitting environments]]
-- [[mesocosm/showcase|Showcase]]
-- [[mesocosm/command-reference#running-benchmarks|Command reference — Run and eval]]
+- [[Sweccathon/mesocosm/local-development|Local development]]
+- [[Sweccathon/mesocosm/submitting-environments|Submitting environments]]
+- [[Sweccathon/mesocosm/showcase|Showcase]]
+- [[Sweccathon/mesocosm/command-reference#running-benchmarks|Command reference — Run and eval]]

--- a/content/Sweccathon/mesocosm/showcase.md
+++ b/content/Sweccathon/mesocosm/showcase.md
@@ -50,7 +50,7 @@ The export includes run data suitable for replay or analysis (episodes, traces, 
 
 ## Typical workflow
 
-1. [[mesocosm/running-benchmarks|Run a platform benchmark]] and wait for completion
+1. [[Sweccathon/mesocosm/running-benchmarks|Run a platform benchmark]] and wait for completion
 2. `mesocosm run get RUN_ID` — confirm status and scores
 3. `mesocosm run export RUN_ID -o showcase/replay.json`
 4. Review JSON locally; commit to GitHub if sharing with reviewers
@@ -74,10 +74,10 @@ When creating runs, you can set visibility for gallery features:
 mesocosm run create ... --visibility gallery_public
 ```
 
-See [[mesocosm/running-benchmarks|Running benchmarks]] for `run create` flags.
+See [[Sweccathon/mesocosm/running-benchmarks|Running benchmarks]] for `run create` flags.
 
 ## Related
 
-- [[mesocosm/running-benchmarks|Running benchmarks]]
-- [[mesocosm/command-reference#mesocosm-run-export|Command reference — run export]]
-- [[mesocosm/local-development|Local development]] — local runs do not produce showcase exports; export is for platform `RUN_ID`s
+- [[Sweccathon/mesocosm/running-benchmarks|Running benchmarks]]
+- [[Sweccathon/mesocosm/command-reference#mesocosm-run-export|Command reference — run export]]
+- [[Sweccathon/mesocosm/local-development|Local development]] — local runs do not produce showcase exports; export is for platform `RUN_ID`s

--- a/content/Sweccathon/mesocosm/submitting-environments.md
+++ b/content/Sweccathon/mesocosm/submitting-environments.md
@@ -29,7 +29,7 @@ mesocosm env submit \
 
 ### Team scope
 
-If you have an [[mesocosm/teams|active team]], submissions default to that team unless you pass `--team` or `--solo`.
+If you have an [[Sweccathon/mesocosm/teams|active team]], submissions default to that team unless you pass `--team` or `--solo`.
 
 ## What happens on submit
 
@@ -58,7 +58,7 @@ Your repo should be suitable for automated clone and run:
 | **`benchanything.json`** at repo root (or path the platform expects) | Defines binding vow, domain metadata, scoring |
 | **`env.py`** + **`adapter.py`** (or equivalent layout from `mesocosm init`) | Runtime environment and HTTP adapter |
 | **`requirements.txt`** (if needed) | Optional extra Python packages installed in the cloud runtime |
-| Working local loop | Validate with [[mesocosm/local-development]] before submit |
+| Working local loop | Validate with [[Sweccathon/mesocosm/local-development]] before submit |
 
 ### Recommended layout (from `mesocosm init`)
 
@@ -84,7 +84,7 @@ mesocosm env submit \
 ## After submit
 
 1. `mesocosm env list` — wait until status indicates ready
-2. [[mesocosm/running-benchmarks|Running benchmarks]] — `mesocosm run create --domain DOMAIN_ID …`
+2. [[Sweccathon/mesocosm/running-benchmarks|Running benchmarks]] — `mesocosm run create --domain DOMAIN_ID …`
 3. Optionally pin an environment: `run create --env-id ENV_ID`
 
 ## Legacy `domain.py` workflow
@@ -107,11 +107,11 @@ mesocosm validate domain.json
 cat domain.json | mesocosm validate -
 ```
 
-See [[mesocosm/command-reference#mesocosm-validate|Command reference — validate]].
+See [[Sweccathon/mesocosm/command-reference#mesocosm-validate|Command reference — validate]].
 
 ## Related
 
-- [[mesocosm/local-development|Local development]]
-- [[mesocosm/running-benchmarks|Running benchmarks]]
-- [[mesocosm/teams|Teams]]
-- [[mesocosm/command-reference#mesocosm-env-submit|Command reference — env submit]]
+- [[Sweccathon/mesocosm/local-development|Local development]]
+- [[Sweccathon/mesocosm/running-benchmarks|Running benchmarks]]
+- [[Sweccathon/mesocosm/teams|Teams]]
+- [[Sweccathon/mesocosm/command-reference#mesocosm-env-submit|Command reference — env submit]]

--- a/content/Sweccathon/mesocosm/teams.md
+++ b/content/Sweccathon/mesocosm/teams.md
@@ -104,7 +104,7 @@ mesocosm run create ... --team TEAM_ID
 mesocosm run create ... --solo
 ```
 
-See [[mesocosm/submitting-environments|Submitting environments]] and [[mesocosm/running-benchmarks|Running benchmarks]].
+See [[Sweccathon/mesocosm/submitting-environments|Submitting environments]] and [[Sweccathon/mesocosm/running-benchmarks|Running benchmarks]].
 
 ## Quick reference
 
@@ -124,9 +124,9 @@ See [[mesocosm/submitting-environments|Submitting environments]] and [[mesocosm/
 | `team leave TEAM_ID` | Leave team |
 | `team delete TEAM_ID` | Delete team (owner) |
 
-Full parameters: [[mesocosm/command-reference#teams|Command reference — Teams]].
+Full parameters: [[Sweccathon/mesocosm/command-reference#teams|Command reference — Teams]].
 
 ## Related
 
-- [[mesocosm/authentication|Authentication]]
-- [[mesocosm/command-reference|Command reference]]
+- [[Sweccathon/mesocosm/authentication|Authentication]]
+- [[Sweccathon/mesocosm/command-reference|Command reference]]

--- a/content/Sweccathon/mesocosm/troubleshooting.md
+++ b/content/Sweccathon/mesocosm/troubleshooting.md
@@ -33,6 +33,8 @@ mesocosm doctor --local
 | Env adapter | `http://127.0.0.1:8765` (override: `MESOCOSM_ENV_URL` or `MESOCOSM_ADAPTER_URL`) |
 | bench-api | `http://127.0.0.1:8010` |
 
+**Note:** In local profile, `doctor` can pass when only the env adapter is healthy. That is expected for the Ollama + `run local` loop even if bench-api is not running.
+
 ## URLs and environment variables {#urls-and-environment-variables}
 
 ### Production bench API must include `/bench`
@@ -127,7 +129,13 @@ Credentials path: `~/.config/swecc/bench_credentials.json` (override with `SWECC
 
 ## `validate` failures
 
-`mesocosm validate` is **offline** — it does not hit the network. A failure means the JSON does not match registration policy. Fix the manifest fields and re-run.
+`mesocosm validate` is **offline** — it does not hit the network. Pass a `benchanything.json` manifest or legacy register JSON:
+
+```bash
+mesocosm validate benchanything.json
+```
+
+A failure means the JSON does not match bundled policy constraints. Fix the reported fields and re-run.
 
 ## Connection errors (general)
 
@@ -144,10 +152,10 @@ mesocosm run --help
 mesocosm auth login --help
 ```
 
-Full flag list: [[mesocosm/command-reference|Command reference]].
+Full flag list: [[Sweccathon/mesocosm/command-reference|Command reference]].
 
 ## Related
 
-- [[mesocosm/getting-started#configure|Getting started — Configure]]
-- [[mesocosm/authentication|Authentication]]
-- [[mesocosm/local-development|Local development]]
+- [[Sweccathon/mesocosm/getting-started#configure|Getting started — Configure]]
+- [[Sweccathon/mesocosm/authentication|Authentication]]
+- [[Sweccathon/mesocosm/local-development|Local development]]


### PR DESCRIPTION
## Summary
- Fix broken wikilinks by using full `Sweccathon/mesocosm/...` paths so Quartz resolves guide pages correctly
- Sync Mesocosm CLI docs with swecc-core main (swecc-mesocosm 0.2.14): `env delete`, `BENCH_AUTH_DISABLED`, validate manifest support, doctor local behavior, and `run create` vs `eval run` differences
- Remove stray macOS metadata files from the Sweccathon content tree

## Test plan
- [x] `npx quartz build` succeeds
- [x] Built HTML links point to `Sweccathon/mesocosm/*` instead of 404 paths
- [ ] Open `/Sweccathon/START_HERE` locally and click through all guide links

Made with [Cursor](https://cursor.com)