### PR TITLE
Sweccathon deck fixes: Advay spelling, Devpost QR + submit micro-steps

### DIFF
--- a/quartz/static/decks/shared/deck.css
+++ b/quartz/static/decks/shared/deck.css
@@ -402,3 +402,9 @@ html, body, .reveal-viewport { background: var(--paper); }
 .qa h2 { font-family:var(--f-display); font-weight:500; font-size:128px; color:var(--ink); margin:0; line-height:1; }
 .qa h2 em { font-style:italic; color:var(--leaf-deep); }
 .qa p { font-family:var(--f-display); font-size:36px; color:var(--ink-2); margin:0; }
+
+/* compact "how to submit" micro-steps */
+.substeps { display:flex; flex-wrap:wrap; align-items:baseline; gap:10px 20px; border-top:1px solid var(--line); padding-top:18px; }
+.substeps .ms-lbl { font-family:var(--f-body); text-transform:uppercase; letter-spacing:0.18em; font-size:13px; color:var(--leaf); width:100%; margin-bottom:4px; }
+.substeps .ms { font-family:var(--f-display); font-size:22px; color:var(--ink); display:inline-flex; align-items:baseline; gap:8px; }
+.substeps .ms b { font-family:var(--f-mono); font-size:15px; color:var(--leaf); font-weight:600; }

--- a/quartz/static/decks/sweccathon/index.html
+++ b/quartz/static/decks/sweccathon/index.html
@@ -137,6 +137,10 @@
           <div class="col col--figure">
             <div class="note"><p class="nt">Everyone submits through <em>Devpost</em>, as a team.</p></div>
             <p class="copy" style="font-size:25px; max-width:34ch; margin-top:22px">A demo site is trivial once you have traces &mdash; point an LLM at your run output and it'll build the visualization for you. Attach the video as an unlisted YouTube link.</p>
+            <div class="demo-foot" style="margin-top:28px">
+              <div class="qbox"><img src="./assets/qr/devpost.png" alt="Devpost QR" /></div>
+              <div class="qmeta"><div class="qu">sweccathon-2026.devpost.com</div><div class="qc">register your team &amp; submit here</div></div>
+            </div>
           </div>
           <span class="pagenum">06 / 12</span>
         </div>
@@ -229,7 +233,7 @@
               <div class="role"><div class="rname">Simon</div><div class="rrole">Lead &amp; organizer &middot; builds mesocosm</div></div>
               <div class="role"><div class="rname">Navneeth</div><div class="rrole">Engineer &middot; mesocosm &amp; food</div></div>
               <div class="role"><div class="rname">Derek</div><div class="rrole">Engineer &middot; tech support</div></div>
-              <div class="role"><div class="rname">Advai</div><div class="rrole">SWECC President &middot; event &amp; closing</div></div>
+              <div class="role"><div class="rname">Advay</div><div class="rrole">SWECC President &middot; event &amp; closing</div></div>
             </div>
           </div>
           <div class="col col--figure">

--- a/quartz/static/decks/sweccathon/index.html
+++ b/quartz/static/decks/sweccathon/index.html
@@ -141,6 +141,13 @@
               <div class="qbox"><img src="./assets/qr/devpost.png" alt="Devpost QR" /></div>
               <div class="qmeta"><div class="qu">sweccathon-2026.devpost.com</div><div class="qc">register your team &amp; submit here</div></div>
             </div>
+            <div class="substeps" style="margin-top:24px; max-width:42ch">
+              <span class="ms-lbl">On Devpost</span>
+              <span class="ms"><b>1</b> create your team</span>
+              <span class="ms"><b>2</b> add your GitHub repo</span>
+              <span class="ms"><b>3</b> add your demo site</span>
+              <span class="ms"><b>4</b> attach your video</span>
+            </div>
           </div>
           <span class="pagenum">06 / 12</span>
         </div>


### PR DESCRIPTION
Follow-up fixes for the SWECCATHON decks (these missed the merge window of #41, which merged with only the original decks).

- **Roles slide:** `Advai` → **`Advay`**
- **Submission slide:** added a **Devpost QR** ("register your team & submit here")
- **Submission slide:** added a compact **"how to submit on Devpost"** micro-flow — create team → add repo → add demo site → attach video (new reusable `.substeps` component in `shared/deck.css`)

Two files changed: `quartz/static/decks/sweccathon/index.html` and `quartz/static/decks/shared/deck.css`. Verified by rendering the submission + roles slides at 1920×1080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
