### PR TITLE
Add example-benchmarks slide (Opus 4.8 system card) to the event deck

### DIFF
--- a/content/Sweccathon/event-slides.md
+++ b/content/Sweccathon/event-slides.md
@@ -35,12 +35,13 @@ Navigate with the on-screen arrows or your keyboard (← / →). Press **F** for
 3. **The three tracks** — Games · AGI/Real-world modeling · Future of work
 4. **Judging** — the scoring rubric
 5. **Submission** — what you ship (repo · UI · demo video)
-6. **API credits** — Cursor
-7. **Prizes & sponsors** — Google, swag, food
-8. **Logistics / FAQ** — credits, docs, teams
-9. **Deadline** — 4 PM Mon June 1 → judging 5 PM
-10. **Roles & support** — the crew + Discord
-11. **Links & QR** — Devpost · Wiki · Discord
+6. **Example benchmarks** — from the Claude Opus 4.8 system card
+7. **API credits** — Cursor
+8. **Prizes & sponsors** — Google, swag, food
+9. **Logistics / FAQ** — credits, docs, teams
+10. **Deadline** — 4 PM Mon June 1 → judging 5 PM
+11. **Roles & support** — the crew + Discord
+12. **Links & QR** — Devpost · Wiki · Discord
 
 ## Related
 

--- a/quartz/static/decks/shared/deck.css
+++ b/quartz/static/decks/shared/deck.css
@@ -408,3 +408,17 @@ html, body, .reveal-viewport { background: var(--paper); }
 .substeps .ms-lbl { font-family:var(--f-body); text-transform:uppercase; letter-spacing:0.18em; font-size:13px; color:var(--leaf); width:100%; margin-bottom:4px; }
 .substeps .ms { font-family:var(--f-display); font-size:22px; color:var(--ink); display:inline-flex; align-items:baseline; gap:8px; }
 .substeps .ms b { font-family:var(--f-mono); font-size:15px; color:var(--leaf); font-weight:600; }
+
+/* example benchmarks showcase (Opus 4.8 system card) */
+.benchgrid { display:grid; grid-template-columns:repeat(3,1fr); gap:22px; }
+.bench-card { border:1px solid var(--line-2); border-radius:6px; padding:22px 26px; display:flex;
+              flex-direction:column; gap:8px; background:rgba(0,0,0,0.14); }
+.bench-card .bhead { display:flex; align-items:center; justify-content:space-between; }
+.bench-card .bi { width:38px; height:38px; color:var(--leaf); flex:none; }
+.bench-card .bi svg { width:100%; height:100%; stroke:currentColor; fill:none; stroke-width:1.8;
+                      stroke-linecap:round; stroke-linejoin:round; }
+.bench-card .bs { font-family:var(--f-display); font-style:italic; font-weight:500; font-size:42px;
+                  color:var(--leaf-deep); line-height:1; }
+.bench-card .bs small { font-size:19px; font-style:normal; color:var(--muted); letter-spacing:0.02em; }
+.bench-card .bn { font-family:var(--f-display); font-size:27px; color:var(--ink); }
+.bench-card .bd { font-family:var(--f-body); font-size:15.5px; line-height:1.4; color:var(--ink-2); }

--- a/quartz/static/decks/sweccathon/index.html
+++ b/quartz/static/decks/sweccathon/index.html
@@ -41,7 +41,7 @@
             <span class="pill">Undergrad</span>
             <span class="pill">Anyone can join</span>
           </div>
-          <span class="pagenum">02 / 12</span>
+          <span class="pagenum">02 / 13</span>
         </div>
       </section>
 
@@ -63,7 +63,7 @@
               <div class="titem"><span class="tk">05</span><div><div class="tt">The tracks</div><div class="td">pick where you compete</div></div></div>
             </div>
           </div>
-          <span class="pagenum">03 / 12</span>
+          <span class="pagenum">03 / 13</span>
         </div>
       </section>
 
@@ -96,7 +96,7 @@
             </div>
           </div>
           <p class="copy" style="font-size:28px; text-align:center; margin-top:6px">Judged across the board on one thing: the <em>wow</em> factor.</p>
-          <span class="pagenum">04 / 12</span>
+          <span class="pagenum">04 / 13</span>
         </div>
       </section>
 
@@ -117,7 +117,7 @@
               <div class="crit"><span class="cname">Presentation clarity</span><span class="cpct">10%</span><span class="cdesc">how clearly you explain it to us</span><span class="bar"><i style="width:10%"></i></span></div>
             </div>
           </div>
-          <span class="pagenum">05 / 12</span>
+          <span class="pagenum">05 / 13</span>
         </div>
       </section>
 
@@ -149,11 +149,74 @@
               <span class="ms"><b>4</b> attach your video</span>
             </div>
           </div>
-          <span class="pagenum">06 / 12</span>
+          <span class="pagenum">06 / 13</span>
         </div>
       </section>
 
-      <!-- L07 · API CREDITS (Cursor) -->
+      <!-- L07 · EXAMPLE BENCHMARKS (Opus 4.8 system card) -->
+      <section>
+        <div class="stage stage--stack">
+          <span class="brand">swe<span class="chev a">&lt;</span><span class="chev b">&lt;</span></span>
+          <div>
+            <p class="eyebrow leaf" style="margin-bottom:18px">EXAMPLE BENCHMARKS</p>
+            <h2 class="s-display">What the frontier <em>measures.</em></h2>
+            <p class="copy" style="font-size:24px; margin-top:12px; max-width:64ch">Straight from the Claude Opus 4.8 system card &mdash; coding, computer-use, science, real work. Your environment could be the next one on a list like this.</p>
+          </div>
+          <div class="benchgrid">
+            <div class="bench-card">
+              <div class="bhead">
+                <span class="bi"><svg viewBox="0 0 24 24"><path d="M9 8l-4 4 4 4M15 8l4 4-4 4"/></svg></span>
+                <span class="bs">88.6<small>%</small></span>
+              </div>
+              <div class="bn">SWE-bench Verified</div>
+              <div class="bd">Resolve real GitHub issues, end to end.</div>
+            </div>
+            <div class="bench-card">
+              <div class="bhead">
+                <span class="bi"><svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M7 9l3 3-3 3M13 16h4"/></svg></span>
+                <span class="bs">74.6<small>%</small></span>
+              </div>
+              <div class="bn">Terminal-Bench 2.1</div>
+              <div class="bd">Drive a real terminal to finish tasks.</div>
+            </div>
+            <div class="bench-card">
+              <div class="bhead">
+                <span class="bi"><svg viewBox="0 0 24 24"><path d="M9 3h6M10 3v6l-5 8.5A1.5 1.5 0 0 0 6.3 20h11.4a1.5 1.5 0 0 0 1.3-2.5L14 9V3M7.5 14h9"/></svg></span>
+                <span class="bs">93.6<small>%</small></span>
+              </div>
+              <div class="bn">GPQA Diamond</div>
+              <div class="bd">PhD-level science reasoning.</div>
+            </div>
+            <div class="bench-card">
+              <div class="bhead">
+                <span class="bi"><svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 9h18M6.5 6.5h.01M9 6.5h.01"/></svg></span>
+                <span class="bs">84<small>%</small></span>
+              </div>
+              <div class="bn">Online-Mind2Web</div>
+              <div class="bd">Complete real tasks across live websites.</div>
+            </div>
+            <div class="bench-card">
+              <div class="bhead">
+                <span class="bi"><svg viewBox="0 0 24 24"><rect x="3" y="7" width="18" height="13" rx="2"/><path d="M8 7V5.5A2.5 2.5 0 0 1 10.5 3h3A2.5 2.5 0 0 1 16 5.5V7M3 12.5h18"/></svg></span>
+                <span class="bs">1890<small> Elo</small></span>
+              </div>
+              <div class="bn">GDPval-AA</div>
+              <div class="bd">Economically valuable, real-world knowledge work.</div>
+            </div>
+            <div class="bench-card">
+              <div class="bhead">
+                <span class="bi"><svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="2.2"/><circle cx="18" cy="6" r="2.2"/><circle cx="12" cy="18" r="2.2"/><path d="M7.7 7.6L11 15.8M16.3 7.6L13 15.8M8.2 6h7.6"/></svg></span>
+                <span class="bs">82.2<small>%</small></span>
+              </div>
+              <div class="bn">MCP-Atlas</div>
+              <div class="bd">Use external tools through MCP servers.</div>
+            </div>
+          </div>
+          <span class="pagenum">07 / 13</span>
+        </div>
+      </section>
+
+      <!-- L08 · API CREDITS (Cursor) -->
       <section>
         <div class="stage stage--split">
           <span class="brand">swe<span class="chev a">&lt;</span><span class="chev b">&lt;</span></span>
@@ -167,7 +230,7 @@
             <div class="stat" style="margin-bottom:30px"><div class="sv">60</div><div class="sl">credits to give out</div></div>
             <div class="note"><p class="nt">Already on Claude Code or a paid AI plan? Please <em>skip a code</em> so others can grab one. Out of credits? Come find us &mdash; if we have extra, we'll happily hand more out.</p></div>
           </div>
-          <span class="pagenum">07 / 12</span>
+          <span class="pagenum">08 / 13</span>
         </div>
       </section>
 
@@ -190,7 +253,7 @@
             </ul>
             <div class="note"><p class="nt">Track prizes: <em>TODO</em> &mdash; being finalized. Stay tuned on Discord.</p></div>
           </div>
-          <span class="pagenum">08 / 12</span>
+          <span class="pagenum">09 / 13</span>
         </div>
       </section>
 
@@ -207,7 +270,7 @@
             <div class="faq"><div class="q">Where are the docs?</div><div class="a">Everything's in the SWECC wiki and the <span class="mono">mesocosm</span> CLI &mdash; more than enough to get started. <span class="mono">wiki.swecc.org/Sweccathon</span></div></div>
             <div class="faq"><div class="q">How do teams form?</div><div class="a">Solo or up to four. Use the <strong>#team-formation</strong> channel in the SWECC Discord.</div></div>
           </div>
-          <span class="pagenum">09 / 12</span>
+          <span class="pagenum">10 / 13</span>
         </div>
       </section>
 
@@ -225,7 +288,7 @@
             <div class="stat"><div class="sv" style="font-size:60px">5:00 PM</div><div class="sl">judging begins &mdash; in person</div></div>
           </div>
           <p class="copy" style="font-size:26px; max-width:52ch">Top 5 from Devpost present 3–5 min at the closing ceremony. Judges pick <strong>three winners &mdash; one per track</strong> &mdash; plus one <em>overall</em> winner.</p>
-          <span class="pagenum">10 / 12</span>
+          <span class="pagenum">11 / 13</span>
         </div>
       </section>
 
@@ -252,7 +315,7 @@
               <li>#tech-support &mdash; Simon, Derek &amp; Navneeth are watching</li>
             </ul>
           </div>
-          <span class="pagenum">11 / 12</span>
+          <span class="pagenum">12 / 13</span>
         </div>
       </section>
 
@@ -269,7 +332,7 @@
             <div class="qr-card"><div class="qbox"><img src="./assets/qr/wiki.png" alt="Wiki QR" /></div><div class="qlabel">Wiki &amp; docs</div><div class="qurl">wiki.swecc.org/Sweccathon</div></div>
             <div class="qr-card"><div class="qbox"><img src="./assets/qr/discord.png" alt="Discord QR" /></div><div class="qlabel">Discord</div><div class="qurl">discord.gg/VjWAHf9U7</div></div>
           </div>
-          <span class="pagenum">12 / 12</span>
+          <span class="pagenum">13 / 13</span>
         </div>
       </section>
 


### PR DESCRIPTION
Adds an **example-benchmarks** slide to the SWECCATHON event deck, right before the Cursor sponsor section (new slide 07/13).

A 6-card grid showcasing benchmarks from the **Claude Opus 4.8 system card**, each with a themed icon, score, and one-line description — framed as "what the frontier measures; your environment could be next":

| Benchmark | Score | Measures |
|---|---|---|
| SWE-bench Verified | 88.6% | agentic coding (resolve real GitHub issues) |
| Terminal-Bench 2.1 | 74.6% | terminal / computer use |
| GPQA Diamond | 93.6% | graduate-level science reasoning |
| Online-Mind2Web | 84% | live web/browser agent tasks |
| GDPval-AA | 1890 Elo | economically valuable real-world work |
| MCP-Atlas | 82.2% | tool use via MCP servers |

- Representative line-icons (not scraped logos — most academic benchmarks have none, and Anthropic's chart wouldn't match the deck style).
- Page numbers renumbered to a clean 13-slide sequence; the `event-slides` wiki page's "What's inside" list updated to match.
- Source: Anthropic — Introducing Claude Opus 4.8 (anthropic.com/news/claude-opus-4-8) + reported system-card numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
