### PR TITLE
Closing deck: remove '+ guest judges' placeholder (follow-up to #45)

### DIFF
--- a/quartz/static/decks/closing/index.html
+++ b/quartz/static/decks/closing/index.html
@@ -93,7 +93,6 @@
             <div class="role"><div class="rname">Rogerio Panigassi</div><div class="rrole">Google &middot; SRE</div></div>
             <div class="role"><div class="rname">Niti Shah</div><div class="rrole">Google &middot; Software Engineer</div></div>
             <div class="role"><div class="rname">Raman Singh</div><div class="rrole">Google</div></div>
-            <div class="role"><div class="rname">+ guest judges</div><div class="rrole">Google</div></div>
             <div class="role"><div class="rname">Simon Kurgan</div><div class="rrole">SWECC &middot; host</div></div>
             <div class="role"><div class="rname">Sophia Lin</div><div class="rrole">SWECC &middot; host</div></div>
           </div>


### PR DESCRIPTION
Follow-up to #45 (which merged before this fix landed). Removes the leftover **"+ guest judges"** placeholder card from the closing deck's judges slide — the three named Google judges are the full panel.

Panel now: Rogerio Panigassi · Niti Shah · Raman Singh (Google) + hosts Simon Kurgan & Sophia Lin (SWECC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
